### PR TITLE
Add mouse motion support

### DIFF
--- a/Framework/Input/Input.cs
+++ b/Framework/Input/Input.cs
@@ -134,6 +134,12 @@ namespace Foster.Framework
             nextState.Mouse.wheelValue = new Vector2(offsetX, offsetY);
         }
 
+        protected void OnMouseMotion(float x, float y)
+        {
+            nextState.Mouse.mousePosition.X = (int) x;
+            nextState.Mouse.mousePosition.Y = (int) y;
+        }
+
         protected void OnJoystickConnect(uint index, string name, uint buttonCount, uint axisCount, bool isGamepad)
         {
             if (index < InputState.MaxControllers)

--- a/Framework/Input/Mouse.cs
+++ b/Framework/Input/Mouse.cs
@@ -15,6 +15,7 @@ namespace Foster.Framework
         internal readonly bool[] released = new bool[MaxButtons];
         internal readonly long[] timestamp = new long[MaxButtons];
         internal Vector2 wheelValue;
+        internal Point2 mousePosition;
 
         public bool Pressed(MouseButtons button) => pressed[(int)button];
         public bool Down(MouseButtons button) => down[(int)button];
@@ -33,6 +34,7 @@ namespace Foster.Framework
         public bool MiddleReleased => released[(int)MouseButtons.Middle];
 
         public Vector2 Wheel => wheelValue;
+        public Point2 Position => mousePosition;
 
         internal void Copy(Mouse other)
         {
@@ -42,6 +44,7 @@ namespace Foster.Framework
             Array.Copy(other.timestamp, 0, timestamp, 0, MaxButtons);
 
             wheelValue = other.wheelValue;
+            mousePosition = other.mousePosition;
         }
 
         internal void Step()
@@ -50,6 +53,5 @@ namespace Foster.Framework
             Array.Fill(released, false);
             wheelValue = Vector2.Zero;
         }
-
     }
 }

--- a/Platforms/GLFW/GLFW_Input.cs
+++ b/Platforms/GLFW/GLFW_Input.cs
@@ -55,6 +55,7 @@ namespace Foster.GLFW
             GLFW.SetKeyCallback(window, TrackDelegate<GLFW.KeyFunc>(window, OnKeyCallback));
             GLFW.SetCharCallback(window, TrackDelegate<GLFW.CharFunc>(window, OnCharCallback));
             GLFW.SetMouseButtonCallback(window, TrackDelegate<GLFW.MouseButtonFunc>(window, OnMouseCallback));
+            GLFW.SetCursorPosCallback(window, TrackDelegate<GLFW.CursorPosFunc>(window, OnMouseMotionCallback));
             GLFW.SetScrollCallback(window, TrackDelegate<GLFW.ScrollFunc>(window, OnScrollCallback));
         }
 
@@ -174,6 +175,11 @@ namespace Foster.GLFW
                     OnMouseUp(mb);
                 ignoreMouseUp[button] = false;
             }
+        }
+
+        private void OnMouseMotionCallback(IntPtr window, double x, double y)
+        {
+            OnMouseMotion((float)x, (float)y);
         }
 
         private void OnScrollCallback(IntPtr window, double offsetX, double offsetY)

--- a/Platforms/SDL2/SDL_Input.cs
+++ b/Platforms/SDL2/SDL_Input.cs
@@ -86,6 +86,10 @@ namespace Foster.SDL2
             {
                 OnMouseWheel(e.wheel.x, e.wheel.y);
             }
+            else if (e.type == SDL.SDL_EventType.SDL_MOUSEMOTION)
+            {
+                OnMouseMotion(e.motion.x, e.motion.y);
+            }
             // joystick
             else if (e.type == SDL.SDL_EventType.SDL_JOYDEVICEADDED)
             {

--- a/Platforms/SDL2/SDL_System.cs
+++ b/Platforms/SDL2/SDL_System.cs
@@ -108,6 +108,7 @@ namespace Foster.SDL2
                     case SDL.SDL_EventType.SDL_MOUSEBUTTONDOWN:
                     case SDL.SDL_EventType.SDL_MOUSEBUTTONUP:
                     case SDL.SDL_EventType.SDL_MOUSEWHEEL:
+                    case SDL.SDL_EventType.SDL_MOUSEMOTION:
                     case SDL.SDL_EventType.SDL_JOYAXISMOTION:
                     case SDL.SDL_EventType.SDL_JOYBALLMOTION:
                     case SDL.SDL_EventType.SDL_JOYHATMOTION:


### PR DESCRIPTION
- Added a new `Point2 Position` property to `Mouse`.
- Added GLFW callback and SDL2 event handling to get mouse position.

Note that SDL2's mouse position is always as integers (but with float type), while GLFW provides double-precision floating point values. To make the framework platform agnostic, I chose to cast both to integers. This shouldn't be a problem since mouse positions don't really need to be floating points.