### PR TITLE
Fixed index parameter passthrough for Packer.Add() overload

### DIFF
--- a/Framework/Images/Packer.cs
+++ b/Framework/Images/Packer.cs
@@ -133,7 +133,7 @@ public class Packer
 
 	public int Add(int index, string name, int width, int height, ReadOnlySpan<Color> pixels)
 	{
-		return Add(sources.Count, name, new RectInt(0, 0, width, height), width, pixels);
+		return Add(index, name, new RectInt(0, 0, width, height), width, pixels);
 	}
 
 	public int Add(int index, string name, RectInt clip, int stride, ReadOnlySpan<Color> pixels)


### PR DESCRIPTION
- Fixes Packer.Add() index parameter passthrough bug.
- Fixes SpriteFont constructor failing.