### PR TITLE
Building universal binary of platform lib on macOS

### DIFF
--- a/Platform/CMakeLists.txt
+++ b/Platform/CMakeLists.txt
@@ -7,6 +7,11 @@ if (WIN32)
 	option(FOSTER_D3D11_ENABLED "Make D3D11 Renderer available" ON)
 endif()
 
+# Set flag for building a universal binary on macOS 
+if(APPLE)
+	set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64")
+endif()
+
 # Default to Release build for library
 if(NOT CMAKE_BUILD_TYPE)
 	set(CMAKE_BUILD_TYPE Release)


### PR DESCRIPTION
Fixes #26. Because the GitHub runners are intel-based, the macOS binaries of the platform lib built in the Actions workflow were only compatible with x64 machines. To solve this issue, following [this SO answer](https://stackoverflow.com/questions/65157483/macos-build-universal-binary-2-with-cmake), a CMake option is included to build universal binaries on macOS, allowing the library to run on arm machines. 