### PR TITLE
Two little things.

### DIFF
--- a/Framework/Extensions/VectorExt.cs
+++ b/Framework/Extensions/VectorExt.cs
@@ -48,6 +48,12 @@ public static class VectorExt
 		=> new((int)MathF.Round(vector.X), (int)MathF.Round(vector.Y));
 
 	/// <summary>
+	/// Floors the individual components of a Vector2
+	/// </summary>
+	public static Point2 FloorToPoint2(this Vector2 vector)
+		=> new((int)MathF.Floor(vector.X), (int)MathF.Floor(vector.Y));
+
+	/// <summary>
 	/// Rounds the individual components of a Vector3
 	/// </summary>
 	public static Vector3 Round(this Vector3 vector)

--- a/Framework/Images/Color.cs
+++ b/Framework/Images/Color.cs
@@ -23,6 +23,7 @@ public struct Color : IEquatable<Color>
 	public static readonly Color Green = new(0x00ff00);
 	public static readonly Color Blue = new(0x0000ff);
 	public static readonly Color Yellow = new(0xffff00);
+	public static readonly Color CornflowerBlue = new(0x6495ed);
 
 	public byte R;
 	public byte G;


### PR DESCRIPTION
*Add FloorToPoint2 extension method
*Add CornflowerBlue color just for fun.

Question:
Should we prefer using 'Calc' class over making direct calls to Math or MathF ?
In the 'VectorExt.cs'  'MathF.Round' is used, even though comment on method 'Calc.Round' says "Always round using this!"
