### PR TITLE
Font(string path) now uses File.OpenRead, SpriteFont now disposes Font where possible

### DIFF
--- a/Framework/Graphics/SpriteFont.cs
+++ b/Framework/Graphics/SpriteFont.cs
@@ -96,7 +96,7 @@ public class SpriteFont
 
 	public SpriteFont(string path, float size, ReadOnlySpan<int> codepoints)
 	{
-		var font = new Font(path);
+		using var font = new Font(path);
 		InitializeFromFont(font, size, codepoints);
 	}
 
@@ -105,7 +105,7 @@ public class SpriteFont
 
 	public SpriteFont(Stream stream, float size, ReadOnlySpan<int> codepoints)
 	{
-		var font = new Font(stream);
+		using var font = new Font(stream);
 		InitializeFromFont(font, size, codepoints);
 	}
 

--- a/Framework/Images/Font.cs
+++ b/Framework/Images/Font.cs
@@ -40,7 +40,7 @@ public class Font : IDisposable
 
 	public Font(string path)
 	{
-		using var stream = File.Open(path, FileMode.Open);
+		using var stream = File.OpenRead(path);
 		Load(stream);
 	}
 


### PR DESCRIPTION
`Font(string path)` now uses `File.OpenRead`, `SpriteFont` now disposes `Font` where possible.