### PR TITLE
Use for loops over foreach in Material.Get/Apply

### DIFF
--- a/Framework/Graphics/Material.cs
+++ b/Framework/Graphics/Material.cs
@@ -244,8 +244,9 @@ public class Material
 			}
 
 			// apply each uniform value
-			foreach (var uniform in uniforms)
+			for (var i = 0; i < uniforms.Count; i++)
 			{
+				var uniform = uniforms[i];
 				if (IsFloat(uniform.Type))
 				{
 					Platform.FosterShaderSetUniform(id, uniform.Index, floatPtr + uniform.BufferStart);
@@ -267,10 +268,13 @@ public class Material
 	/// </summary>
 	private Uniform Get(string uniform)
 	{
-		foreach (var it in uniforms)
+		for (var i = 0; i < uniforms.Count; i++)
+		{
+			var it = uniforms[i];
 			if (it.Name == uniform)
 				return it;
-			
+		}
+
 		Debug.Assert(false, $"Uniform '{uniform}' does not exist");
 		return default;
 	}


### PR DESCRIPTION
`for` loops are ~2x faster for small `List`s (that we typically deal with here).

In a degenerate case where two alternating textures are drawn via `Batcher`, the time decreases for these methods (percent time in release mode):
- `Material.Get`: 11.06% -> 5.47%
- `Material.Apply`: 8.65% -> 8.09%

A benchmark via `BenchmarkDotNet` shows the improvement as well. I also tested `Dictionary`, `Array`, and `Span` (`Span` with `List` uses `CollectionsMarshal.AsSpan`). Here are the full results with 5 uniforms looking for the last uniform in the list.

<HTML>
<BODY>
<!--StartFragment--><TABLE><THEAD><TH>Case</TH><TH>Mean</TH></THEAD><TR><TD>DictionaryLookup</TD><TD>13.26 ns</TD></TR><TR><TD>ArrayForeach</TD><TD>16.37 ns</TD></TR><TR><TD>ArraySpanForeach</TD><TD>16.53 ns</TD></TR><TR><TD>ArraySpanFor</TD><TD>16.55 ns</TD></TR><TR><TD>ArrayFor</TD><TD>16.82 ns</TD></TR><TR><TD>ListSpanFor</TD><TD>16.93 ns</TD></TR><TR><TD>ListSpanForeach</TD><TD>17.28 ns</TD></TR><TR><TD>ListFor</TD><TD>18.07 ns</TD></TR><TR><TD>ListForeach</TD><TD>31.93 ns</TD></TR></TABLE>
<!--EndFragment-->
</BODY>
</HTML>

As you can see, we can get slightly better results with `List` converted to `Span` using `CollectionsMarshal.AsSpan` at the cost of some transparency. I personally opted to just change to `for` loop to maintain simplicity. Dictionary may be tempting but aside from lookups, just about every other operation is slower for low counts. In fact, lookups near the beginning of a `List` are faster.