### PR TITLE
Fixed QOI test, added QOI write

### DIFF
--- a/Framework/Images/Enums/ImageWriteFormat.cs
+++ b/Framework/Images/Enums/ImageWriteFormat.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-namespace Foster.Framework;
+﻿namespace Foster.Framework;
 
 internal enum ImageWriteFormat
 {

--- a/Framework/Images/Enums/ImageWriteFormat.cs
+++ b/Framework/Images/Enums/ImageWriteFormat.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+namespace Foster.Framework;
+
+internal enum ImageWriteFormat
+{
+	Png,
+	Qoi
+}

--- a/Framework/Images/Image.cs
+++ b/Framework/Images/Image.cs
@@ -161,6 +161,28 @@ public class Image : IDisposable
 	/// </summary>
 	public void WritePng(Stream stream)
 	{
+		Write(stream, ImageWriteFormat.Png);
+	}
+
+	/// <summary>
+	/// Writes the image to a PNG file
+	/// </summary>
+	public void WriteQoi(string path)
+	{
+		using var stream = File.Create(path);
+		WritePng(stream);
+	}
+
+	/// <summary>
+	/// Write the image to QOI
+	/// </summary>
+	public void WriteQoi(Stream stream)
+	{
+		Write(stream, ImageWriteFormat.Qoi);
+	}
+
+	private void Write(Stream stream, ImageWriteFormat format)
+	{
 		static unsafe void Write(IntPtr context, IntPtr data, int size)
 		{
 			var stream = GCHandle.FromIntPtr(context).Target as Stream;
@@ -169,7 +191,7 @@ public class Image : IDisposable
 		}
 
 		GCHandle handle = GCHandle.Alloc(stream);
-		Platform.FosterImageWrite(Write, GCHandle.ToIntPtr(handle), Width, Height, ptr);
+		Platform.FosterImageWrite(Write, GCHandle.ToIntPtr(handle), format, Width, Height, ptr);
 		handle.Free();
 	}
 

--- a/Framework/Platform.cs
+++ b/Framework/Platform.cs
@@ -204,7 +204,7 @@ internal static class Platform
 	[DllImport(DLL)]
 	public static extern void FosterImageFree(IntPtr data);
 	[DllImport(DLL)]
-	public static extern bool FosterImageWrite(FosterWriteFn func, IntPtr context, int w, int h, IntPtr data);
+	public static extern bool FosterImageWrite(FosterWriteFn func, IntPtr context, ImageWriteFormat format, int w, int h, IntPtr data);
 	[DllImport(DLL)]
 	public static extern IntPtr FosterFontInit(IntPtr data, int length);
 	[DllImport(DLL)]

--- a/Platform/include/foster_platform.h
+++ b/Platform/include/foster_platform.h
@@ -392,6 +392,12 @@ typedef enum FosterLogging
 	FOSTER_LOGGING_NONE
 } FosterLogging;
 
+typedef enum FosterImageWriteFormat
+{
+	FOSTER_IMAGE_WRITE_FORMAT_PNG,
+	FOSTER_IMAGE_WRITE_FORMAT_QOI,
+} FosterImageWriteFormat;
+
 typedef void (FOSTER_CALL * FosterLogFn)(const char *msg);
 typedef void (FOSTER_CALL * FosterExitRequestFn)();
 typedef void (FOSTER_CALL * FosterOnTextFn)(const char* txt);
@@ -558,7 +564,7 @@ FOSTER_API unsigned char* FosterImageLoad(const unsigned char* memory, int lengt
 
 FOSTER_API void FosterImageFree(unsigned char* data);
 
-FOSTER_API bool FosterImageWrite(FosterWriteFn* func, void* context, int w, int h, const void* data);
+FOSTER_API bool FosterImageWrite(FosterWriteFn* func, void* context, FosterImageWriteFormat format, int w, int h, const void* data);
 
 FOSTER_API FosterFont* FosterFontInit(unsigned char* data, int length);
 


### PR DESCRIPTION
QOI test seems to not work on my machine. Replaced with magic number test from `qoi_decode`.

Added QOI write functionality.

I'd be open to condense our write methods to:
- `Image.Write(string path, ImageWriteFormat format = ImageWriteFormat.Png)`
- `Image.Write(Stream stream, ImageWriteFormat format = ImageWriteFormat.Png)`

Also not sure about casing when it comes to Png/PNG, Qoi/QOI. Went with only first letter capitalized to stay consistent with existing C# methods, but open to changes here.