### PR TITLE
xml comment fixes & use "see cref"

### DIFF
--- a/Framework/App.cs
+++ b/Framework/App.cs
@@ -29,7 +29,7 @@ public static class App
 	public static bool Running { get; private set; } = false;
 
 	/// <summary>
-	/// If the Application is exiting. Call App.Exit() to exit the Application.
+	/// If the Application is exiting. Call <see cref="App.Exit"/> to exit the Application.
 	/// </summary>
 	public static bool Exiting { get; private set; } = false;
 
@@ -187,7 +187,7 @@ public static class App
 
 	/// <summary>
 	/// What action to perform when the user requests for the Application to exit.
-	/// If not assigned, the default behavior is to call App.Exit();
+	/// If not assigned, the default behavior is to call <see cref="App.Exit"/>.
 	/// </summary>
 	public static Action? OnExitRequested;
 
@@ -216,7 +216,7 @@ public static class App
 
 	/// <summary>
 	/// Runs the Application with the given Module automatically registered.
-	/// Functionally the same as calling Register<T>() followed by Run()
+	/// Functionally the same as calling <see cref="Register{T}"/> followed by <see cref="Run(string, int, int, bool)"/>
 	/// </summary>
 	public static void Run<T>(string applicationName, int width, int height, bool fullscreen = false) where T : Module, new()
 	{

--- a/Framework/Spatial/Facing.cs
+++ b/Framework/Spatial/Facing.cs
@@ -3,7 +3,7 @@
 namespace Foster.Framework;
 
 /// <summary>
-/// A left/right struct, where left < 0 and right >= 0.
+/// A left/right struct, where left &lt; 0 and right >= 0.
 /// Useful for 2D Platformers.
 /// </summary>
 public readonly struct Facing : IEquatable<Facing>

--- a/Framework/Utility/Pool.cs
+++ b/Framework/Utility/Pool.cs
@@ -12,7 +12,7 @@ public interface IPoolable
 }
 
 /// <summary>
-/// Simple static Object pool, call Return(instance) to return objects to the pool.
+/// Simple static Object pool, call <see cref="Return(T)"/> to return objects to the pool.
 /// </summary>
 public static class Pool<T> where T : class, new()
 {
@@ -140,12 +140,12 @@ public static class FramePool
 {
 	/// <summary>
 	/// Action to perform when stepping to the next frame.
-	/// FramePool<T> registers its NextFrame function with this event.
+	/// <see cref="FramePool{T}"/> registers its NextFrame function with this event.
 	/// </summary>
 	internal static event Action? nextFrame;
 
 	/// <summary>
-	/// Shorthand to Generic FramePool<T>.Get.
+	/// Shorthand to Generic <see cref="FramePool{T}.Get"/>.
 	/// </summary>
 	public static T Get<T>() where T : class, new()
 	{


### PR DESCRIPTION
XML comments will be broken if there are angle brackets or other XML reserved characters in them
also, "see cref" s would be more friendly to IDE prompts and document generation 🌱 