### PR TITLE
Avoid usage of bool in foster_platform.h

### DIFF
--- a/Platform/include/foster_platform.h
+++ b/Platform/include/foster_platform.h
@@ -1,7 +1,7 @@
 #ifndef FOSTER_H
 #define FOSTER_H
 
-#include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 // Export API
@@ -21,6 +21,8 @@
 #define FOSTER_MAX_UNIFORM_NAME 64
 #define FOSTER_MAX_UNIFORM_TEXTURES 32
 #define FOSTER_MAX_CONTROLLERS 32
+
+typedef uint8_t FosterBool;
 
 typedef enum FosterRenderers
 {
@@ -401,13 +403,13 @@ typedef enum FosterImageWriteFormat
 typedef void (FOSTER_CALL * FosterLogFn)(const char *msg);
 typedef void (FOSTER_CALL * FosterExitRequestFn)();
 typedef void (FOSTER_CALL * FosterOnTextFn)(const char* txt);
-typedef void (FOSTER_CALL * FosterOnKeyFn)(int key, bool pressed);
-typedef void (FOSTER_CALL * FosterOnMouseButtonFn)(int button, bool pressed);
+typedef void (FOSTER_CALL * FosterOnKeyFn)(int key, FosterBool pressed);
+typedef void (FOSTER_CALL * FosterOnMouseButtonFn)(int button, FosterBool pressed);
 typedef void (FOSTER_CALL * FosterOnMouseMoveFn)(float posX, float posY);
 typedef void (FOSTER_CALL * FosterOnMouseWheelFn)(float offsetX, float offsetY);
-typedef void (FOSTER_CALL * FosterOnControllerConnectFn)(int index, const char* name, int buttonCount, int axisCount, bool isGamepad, uint16_t vendor, uint16_t product, uint16_t version);
+typedef void (FOSTER_CALL * FosterOnControllerConnectFn)(int index, const char* name, int buttonCount, int axisCount, FosterBool isGamepad, uint16_t vendor, uint16_t product, uint16_t version);
 typedef void (FOSTER_CALL * FosterOnControllerDisconnectFn)(int index);
-typedef void (FOSTER_CALL * FosterOnControllerButtonFn)(int index, int button, bool pressed);
+typedef void (FOSTER_CALL * FosterOnControllerButtonFn)(int index, int button, FosterBool pressed);
 typedef void (FOSTER_CALL * FosterOnControllerAxisFn)(int index, int axis, float value);
 typedef void (FOSTER_CALL * FosterWriteFn)(void *context, void *data, int size);
 
@@ -540,7 +542,7 @@ FOSTER_API void FosterEndFrame();
 
 FOSTER_API void FosterShutdown();
 
-FOSTER_API bool FosterIsRunning();
+FOSTER_API FosterBool FosterIsRunning();
 
 FOSTER_API void FosterSetTitle(const char* title);
 
@@ -558,13 +560,13 @@ FOSTER_API void FosterSetClipboard(const char* cstr);
 
 FOSTER_API const char* FosterGetClipboard();
 
-FOSTER_API bool FosterGetFocused();
+FOSTER_API FosterBool FosterGetFocused();
 
 FOSTER_API unsigned char* FosterImageLoad(const unsigned char* memory, int length, int* w, int* h);
 
 FOSTER_API void FosterImageFree(unsigned char* data);
 
-FOSTER_API bool FosterImageWrite(FosterWriteFn* func, void* context, FosterImageWriteFormat format, int w, int h, const void* data);
+FOSTER_API FosterBool FosterImageWrite(FosterWriteFn* func, void* context, FosterImageWriteFormat format, int w, int h, const void* data);
 
 FOSTER_API FosterFont* FosterFontInit(unsigned char* data, int length);
 

--- a/Platform/src/foster_image.c
+++ b/Platform/src/foster_image.c
@@ -38,7 +38,7 @@ void FosterImageFree(unsigned char* data)
 	stbi_image_free(data);
 }
 
-bool FosterImageWrite(FosterWriteFn* func, void* context, FosterImageWriteFormat format, int w, int h, const void* data)
+FosterBool FosterImageWrite(FosterWriteFn* func, void* context, FosterImageWriteFormat format, int w, int h, const void* data)
 {
 	// note: 'FosterWriteFn' and 'stbi_write_func' must be the same
 	switch (format)

--- a/Platform/src/foster_internal.h
+++ b/Platform/src/foster_internal.h
@@ -8,7 +8,7 @@
 // foster global state
 typedef struct
 {
-	bool running;
+	FosterBool running;
 	FosterDesc desc;
 	FosterFlags flags;
 	FosterRenderDevice device;

--- a/Platform/src/foster_platform.c
+++ b/Platform/src/foster_platform.c
@@ -317,7 +317,7 @@ void FosterShutdown()
 	SDL_DestroyWindow(fstate.window);
 }
 
-bool FosterIsRunning()
+FosterBool FosterIsRunning()
 {
 	return fstate.running;
 }
@@ -399,7 +399,7 @@ const char* FosterGetClipboard()
 	return fstate.clipboardText;
 }
 
-bool FosterGetFocused()
+FosterBool FosterGetFocused()
 {
 	FOSTER_ASSERT_RUNNING_RET(FosterGetClipboard, false);
 	Uint32 flags = SDL_GetWindowFlags(fstate.window);

--- a/Platform/src/foster_renderer.h
+++ b/Platform/src/foster_renderer.h
@@ -2,6 +2,7 @@
 #define FOSTER_RENDERER_H
 
 #include "foster_platform.h"
+#include <stdbool.h>
 
 typedef struct FosterRenderDevice
 {


### PR DESCRIPTION
Avoid usage of bool (as it has C# issues) and add FosterBool (which is typedef to uint8_t/byte C#), as per https://github.com/NoelFB/Foster/commit/9852f3e3b75fbfe119ddf3063b4fd398b8caf5a2