### PR TITLE
Add  constructor: Aseprite(Stream stream)

### DIFF
--- a/Framework/Images/Aseprite.cs
+++ b/Framework/Images/Aseprite.cs
@@ -208,6 +208,11 @@ public class Aseprite : Aseprite.IUserDataTarget
 		Load(bin);
 	}
 
+	public Aseprite(Stream stream)
+	{
+		using var bin = new BinaryReader(stream);
+		Load(bin);
+	}
 	private void Load(BinaryReader bin)
 	{
 		// Shorthand methods to match Aseprite's naming convention


### PR DESCRIPTION
Since content API (#37) returns stream objects, we should be able to load Aseprite directly from these.